### PR TITLE
Add devcontainer for Rust development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# Системные зависимости для нативных crates:
+# - cmake, protobuf-compiler: lancedb (Arrow/Lance)
+# - libssl-dev, pkg-config: общие нативные зависимости
+# - libsqlite3-dev: rusqlite (fallback, основной режим — bundled)
+# - libclang-dev: bindgen (ort, lancedb)
+# - libzstd-dev: zstd (fallback, основной режим — bundled)
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        cmake \
+        protobuf-compiler \
+        libprotobuf-dev \
+        pkg-config \
+        libssl-dev \
+        libclang-dev \
+        libzstd-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# cargo-binstall для быстрой установки cargo-инструментов
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Полезные cargo-инструменты
+RUN cargo binstall -y \
+    cargo-watch \
+    cargo-nextest \
+    cargo-deny

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,10 @@
     "dockerfile": "Dockerfile"
   },
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
   },
   "customizations": {
     "vscode": {
@@ -41,5 +44,5 @@
     "source=lokb-cargo-git,target=/usr/local/cargo/git,type=volume",
     "source=lokb-target,target=${containerWorkspaceFolder}/target,type=volume"
   ],
-  "postCreateCommand": "cargo fetch 2>/dev/null || true"
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && cargo fetch 2>/dev/null || true"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+{
+  "name": "lokb",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.cargo.allTargets": true,
+        "editor.formatOnSave": true,
+        "[rust]": {
+          "editor.defaultFormatter": "rust-lang.rust-analyzer"
+        }
+      },
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml",
+        "fill-labs.dependi",
+        "serayuzgur.crates"
+      ]
+    }
+  },
+  "forwardPorts": [7890],
+  "portsAttributes": {
+    "7890": {
+      "label": "lokb serve",
+      "onAutoForward": "notify"
+    }
+  },
+  "containerEnv": {
+    "RUST_BACKTRACE": "1",
+    "RUST_LOG": "info"
+  },
+  "mounts": [
+    "source=lokb-cargo-registry,target=/usr/local/cargo/registry,type=volume",
+    "source=lokb-cargo-git,target=/usr/local/cargo/git,type=volume",
+    "source=lokb-target,target=${containerWorkspaceFolder}/target,type=volume"
+  ],
+  "postCreateCommand": "cargo fetch 2>/dev/null || true"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Проект
+
+lokb (Local Offline Knowledge Base) — персональная offline библиотека знаний на Rust. Объединяет публичные данные (Wikipedia, Wikidata, книги, статьи) и личные (чаты, заметки, фото, GPS) в единую поисковую систему с поддержкой FTS, semantic search и knowledge graph.
+
+**Статус:** Pre-Phase 0. Код ещё не написан, есть только техническое задание в README.md.
+
+## Команды сборки и разработки
+
+```bash
+cargo build                    # сборка всего workspace
+cargo build -p lokb-core       # сборка одного crate
+cargo test                     # все тесты
+cargo test -p lokb-core        # тесты одного crate
+cargo test test_name           # один тест
+cargo clippy --workspace       # линтер
+cargo fmt --all                # форматирование
+cargo run -p lokb-cli -- <cmd> # запуск CLI
+```
+
+## Архитектура
+
+### Четырёхслойное хранение
+
+```
+RAW SOURCE → OPTIMIZED SOURCE → DERIVED → CACHE
+```
+
+- **RAW** — исходные файлы (ZIM, PDF, JSON dump). Удаляемые после обработки.
+- **OPTIMIZED** — нормализованный текст в cluster-bundle zstd формате. Source of truth.
+- **DERIVED** — индексы: chunks (LanceDB), FTS (Tantivy), embeddings (LanceDB), entities (LanceDB+SQLite), catalog (SQLite).
+- **CACHE** — рендеренные документы, LRU eviction.
+
+### Workspace crates (13 штук)
+
+| Crate | Назначение |
+|---|---|
+| `lokb-core` | Типы, трейты, конфиг, budget manager |
+| `lokb-storage` | Content Store + LanceDB + SQLite |
+| `lokb-pipeline` | Pipeline framework (PipelineStep trait, executor) |
+| `lokb-optimize` | RAW → OPTIMIZED оркестратор |
+| `lokb-ingest` | OPTIMIZED → DERIVED оркестратор |
+| `lokb-parsers` | Парсеры форматов (ZIM, PDF, EPUB, Telegram, RDF, Wikidata, ...) |
+| `lokb-search` | Query engine, hybrid search, RRF, skills |
+| `lokb-embed` | Embedding модели (ONNX/Candle) |
+| `lokb-llm` | LLM бэкенды (Ollama, ONNX, Candle, OpenAI-compatible) |
+| `lokb-graph` | Entity resolution, relations |
+| `lokb-render` | Source Viewer (terminal ratatui + HTML) |
+| `lokb-serve` | HTTP сервер (axum), будущий MCP |
+| `lokb-cli` | CLI (clap) + TUI (ratatui) |
+
+### Ключевые типы данных
+
+- **Document** — иерархическая единица (Book→Chapter→Chunk, Conversation→Thread→Chunk)
+- **Chunk** — единица поиска с optional embedding vector
+- **Entity** — узел knowledge graph (Wikidata, NER)
+- **Relation** — ребро графа
+- **DataSource** — источник данных (Public или Personal с privacy levels)
+
+### Pipeline
+
+Composable цепочка PipelineStep: extractors → enrichers → transformers → writers. Конфигурируется через TOML. LLM-шаги опциональны с fallback = "skip".
+
+## Ключевые зависимости
+
+- **Storage:** lancedb, rusqlite (bundled), tantivy
+- **RDF:** oxrdfio, oxttl, oxrdf (Oxigraph crates)
+- **ML:** ort (ONNX Runtime, load-dynamic)
+- **Compression:** zstd, blake3
+- **Async:** tokio, axum
+- **CLI:** clap (derive), ratatui
+- **Data:** arrow-array, serde, uuid (v7), chrono
+
+## Физическая структура данных
+
+Всё хранится в `~/.local/share/lokb/` с подкаталогами: `raw/`, `source/`, `derived/`, `cache/`, `models/`.
+
+## Принципы разработки
+
+- **Offline-first** — всё работает без интернета
+- **CLI-first** — composable unix tool, pipe-friendly (JSON/text output)
+- **Embedding search опционален** — FTS и browse доступны сразу, vectors вычисляются в фоне
+- **Privacy levels** (Public/Internal/Private/Secret) — личные данные не смешиваются с публичными при export
+- Default embedding модель: `multilingual-e5-small` (384 dims, 120MB)


### PR DESCRIPTION
## Summary
- Добавлен `.devcontainer/` с Dockerfile и devcontainer.json
- Базовый образ: `mcr.microsoft.com/devcontainers/rust:1-bookworm`
- Системные зависимости: cmake, protobuf-compiler, libssl-dev, libclang-dev, libzstd-dev
- VS Code расширения: rust-analyzer, CodeLLDB, Even Better TOML, Dependi, crates
- Cargo-утилиты: cargo-watch, cargo-nextest, cargo-deny
- Кеширование: cargo registry, git, target dir через named volumes
- Проброс порта 7890 (lokb serve)
- Добавлен CLAUDE.md с описанием архитектуры и командами разработки

## Test plan
- [ ] Открыть проект в VS Code с расширением Dev Containers
- [ ] Убедиться что контейнер собирается без ошибок
- [ ] Проверить что rust-analyzer, clippy, rustfmt доступны
- [ ] Проверить что cargo-watch, cargo-nextest, cargo-deny установлены

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)