### PR TITLE
fix(ci): enable GitHub Pages in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,6 +45,8 @@ jobs:
         run: pnpm run build
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- Add `enablement: true` to `actions/configure-pages@v5` to auto-enable Pages environment

## Problem
Deploy failed with:
```
Error: Get Pages site failed. Please verify that the repository has Pages enabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)