### PR TITLE
ci: add code coverage with cargo-llvm-cov + Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
       - run: cargo test --test e2e -p lokb-cli
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- New `coverage` CI job: cargo-llvm-cov → lcov.info → Codecov upload
- `fail_ci_if_error: false` — не блокирует CI пока Codecov не настроен

## Test plan
- [ ] Coverage job проходит в CI
- [ ] Codecov получает данные (после настройки token)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)